### PR TITLE
Remove deprecated 'DUMP TRUE' from mapfiles.

### DIFF
--- a/demo/census/census.map
+++ b/demo/census/census.map
@@ -47,7 +47,6 @@ MAP
     LAYER
         NAME census_cities
         STATUS ON
-        DUMP TRUE
 
         METADATA
             'ows_title' 'Cities'
@@ -94,7 +93,6 @@ MAP
     LAYER
         NAME census_roads
         STATUS ON
-        DUMP TRUE
 
         METADATA
             'ows_title' 'Roads'
@@ -140,7 +138,6 @@ MAP
     LAYER
         NAME census_landmarks
         STATUS ON
-        DUMP TRUE
 
         METADATA
             'ows_title' 'Landmarks'

--- a/demo/grids/grids.map
+++ b/demo/grids/grids.map
@@ -36,7 +36,6 @@ MAP
 	LAYER
 		NAME grid_1km
 		STATUS ON
-		DUMP TRUE
 
 		METADATA
 			'ows_title' '1000m Grid'
@@ -64,7 +63,6 @@ MAP
 	LAYER
 		NAME grid_1mile
 		STATUS ON
-		DUMP TRUE
 
 		METADATA
 			'ows_title' '1 mile Grid'

--- a/demo/parcels/parcels.map
+++ b/demo/parcels/parcels.map
@@ -39,7 +39,6 @@ MAP
 		NAME parcels
 		GROUP parcels_group
 		STATUS ON
-        DUMP TRUE
 
 		METADATA
 			'ows_title' 'Parcel Polygons'


### PR DESCRIPTION
'DUMP TRUE' enabled WFS was deprecated in MapServer 6 and will no longer
be allowed in the upcomming MapServer 8.  This is currently handled by
METADATA items.

refs: geomoose/gm3#639