### PR TITLE
OPACITY outside of STYLE will fail in Mapserver 8

### DIFF
--- a/demo/statedata/basemap.map
+++ b/demo/statedata/basemap.map
@@ -112,7 +112,7 @@ MAP
 				PRIORITY 4
 			END
 		END
-		OPACITY 50
+#		OPACITY 50
 		TEMPLATE 'dummy'
 	END # City Boundary Polygon Layer
 


### PR DESCRIPTION
Suggest either removing, or moving into a STYLE block if you really want to keep it