### PR TITLE
wrap OPACITY in COMPOSITE object

### DIFF
--- a/demo/statedata/basemap.map
+++ b/demo/statedata/basemap.map
@@ -112,7 +112,7 @@ MAP
 				PRIORITY 4
 			END
 		END
-		COMPOSITE
+        COMPOSITE
           OPACITY 50
         END
 		TEMPLATE 'dummy'

--- a/demo/statedata/basemap.map
+++ b/demo/statedata/basemap.map
@@ -112,7 +112,9 @@ MAP
 				PRIORITY 4
 			END
 		END
-#		OPACITY 50
+		COMPOSITE
+          OPACITY 50
+        END
 		TEMPLATE 'dummy'
 	END # City Boundary Polygon Layer
 

--- a/demo/statedata/basemap.map
+++ b/demo/statedata/basemap.map
@@ -112,9 +112,9 @@ MAP
 				PRIORITY 4
 			END
 		END
-        COMPOSITE
-          OPACITY 50
-        END
+		COMPOSITE
+			OPACITY 50
+		END
 		TEMPLATE 'dummy'
 	END # City Boundary Polygon Layer
 


### PR DESCRIPTION
- I think just commenting out OPACITY (#10) would appear that to re-enable it (to a new user, who would just remove that comment in the mapfile), it should work at the layer-level (which of course breaks with MapServer 8)
- this uses the proper COMPOSITE object for OPACITY