### PR TITLE
disable MapServer log entries

### DIFF
--- a/demo/census/census.map
+++ b/demo/census/census.map
@@ -24,7 +24,7 @@
 
 MAP
     INCLUDE '../../geomoose_globals.map'
-    DEBUG 5
+    #DEBUG 5
     WEB
         METADATA
             'ows_title' 'GeoMoose Example Census data'

--- a/demo/parcels/parcels.map
+++ b/demo/parcels/parcels.map
@@ -33,7 +33,7 @@ MAP
 		END
 	END
 
-    DEBUG 5
+    #DEBUG 5
 
 	LAYER
 		NAME parcels

--- a/geomoose_globals.map
+++ b/geomoose_globals.map
@@ -22,7 +22,7 @@
 # SOFTWARE.
 #
 
-# A convienent place to setup a bunch of defaults for MapServer
+# A convenient place to setup a bunch of defaults for MapServer
 # so they don't need to be set in every mapfile.
 PROJECTION
     "init=epsg:4326"
@@ -33,7 +33,7 @@ EXTENT -179 -90 179 90
 STATUS ON   # Draw map, not just scalebar
 SIZE 800 650 # Set default image size if not set in URL
 
-CONFIG "MS_ERRORFILE" "stderr" # Log to apache error.log
+#CONFIG "MS_ERRORFILE" "stderr" # Log to apache error.log
 
 # Put MapServer inline with the OGC spec for scale calculations
 # See: WMS 1.3.0 spec Section 7.2.4.6.9


### PR DESCRIPTION
- by default, the demo writes several lines of logs (about 13 lines) to the Apache log, each time the user zooms or interacts with the demo app
- this causes Apache log files to fill & become quite large
- this pull request disables those logs